### PR TITLE
[build, feat, refector, fix] Swagger UI 설정, DB 연동, 예외 처리 기능, Entity 추가, prod /local 환경 구분

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'mysql:mysql-connector-java:8.0.33'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/HelloController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/HelloController.java
@@ -1,0 +1,19 @@
+package com.rofix.fitspot.webservice.api.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Hello Controller", description = "간단한 테스트 API")
+public class HelloController {
+
+    @GetMapping("/hello")
+    @Operation(summary = "Hello", description = "테스트")
+    public String hello() {
+        return "Hello, Spring Boot with Swagger!";
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
@@ -1,0 +1,54 @@
+package com.rofix.fitspot.webservice.api.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "clothes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Clothing {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "clothing_id")
+    private Long clothingId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(nullable = false)
+    private String color;
+
+    @Column(nullable = false, name = "image_url")
+    private String imageUrl;
+
+    @Column
+    private String brand;
+
+    @Column
+    private String season;
+
+    @Column
+    private String description;
+
+    @Column(nullable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    // Cody_Clothes와의 관계 1:N
+    @OneToMany(mappedBy = "cloth")
+    private List<CodyClothes> codyClothes;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Cody.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Cody.java
@@ -1,0 +1,50 @@
+package com.rofix.fitspot.webservice.api.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "cody")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Cody {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cody_id")
+    private Long codyId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String description;
+
+    @Column
+    private String weather;
+
+    @Column(nullable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    // Comments와의 관계 1:N
+    @OneToMany(mappedBy = "cody")
+    private List<Comment> comments;
+
+    // Likes와의 관계: 1:N
+    @OneToMany(mappedBy = "cody")
+    private List<Like> likes;
+
+    // Cody_Clothes와의 관계: 1:N
+    @OneToMany(mappedBy = "cody")
+    private List<CodyClothes> codyClothes;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/CodyClothes.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/CodyClothes.java
@@ -1,0 +1,27 @@
+package com.rofix.fitspot.webservice.api.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cody_clothes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodyClothes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cody_clothing_id")
+    private Long codyClothingId;
+
+    @ManyToOne
+    @JoinColumn(name = "cody_id")
+    private Cody cody;
+
+    @ManyToOne
+    @JoinColumn(name = "cloth_id")
+    private Clothing cloth;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/CodyClothes.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/CodyClothes.java
@@ -22,6 +22,6 @@ public class CodyClothes {
     private Cody cody;
 
     @ManyToOne
-    @JoinColumn(name = "cloth_id")
+    @JoinColumn(name = "clothing_id")
     private Clothing cloth;
 }

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Comment.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Comment.java
@@ -1,0 +1,37 @@
+package com.rofix.fitspot.webservice.api.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    // user 와의 관계 N:1
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // cody 와의 관계 N:1
+    @ManyToOne
+    @JoinColumn(name = "cody_id")
+    private Cody cody;
+
+    @Column
+    private String content;
+
+    @Column
+    private LocalDateTime created_at;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Like.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Like.java
@@ -1,0 +1,29 @@
+package com.rofix.fitspot.webservice.api.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "likes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long like_id;
+
+    // user 와의 관계 N:1
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // cody 와의 관계 N:1
+    @ManyToOne
+    @JoinColumn(name = "cody_id")
+    private Cody cody;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
@@ -40,9 +40,15 @@ public class User {
     private List<Clothing> clothes;
 
     // Cody와 관계
+    @OneToMany(mappedBy = "user")
+    private List<Cody> cody;
 
     // Comments와 관계
+    @OneToMany(mappedBy = "user")
+    private List<Comment> comments;
 
     // Likes와 관계
+    @OneToMany(mappedBy = "user")
+    private List<Like> likes;
 
 }

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
@@ -1,0 +1,48 @@
+package com.rofix.fitspot.webservice.api.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name= "user_id")
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, name = "ip_address")
+    private String ipAddress;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(name = "personal_color")
+    private String personalColor;
+
+    @Column(nullable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    // Clothes와 관계 1:N
+    @OneToMany(mappedBy = "user")
+    private List<Clothing> clothes;
+
+    // Cody와 관계
+
+    // Comments와 관계
+
+    // Likes와 관계
+
+}

--- a/src/main/java/com/rofix/fitspot/webservice/config/OpenApiConfig.java
+++ b/src/main/java/com/rofix/fitspot/webservice/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.rofix.fitspot.webservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Next Java Server API")
+                        .description("Spring Boot REST API Documentation")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/config/WebConfig.java
+++ b/src/main/java/com/rofix/fitspot/webservice/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.rofix.fitspot.webservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**") // 모든 경로에 대해
+                        .allowedOrigins("http://localhost:8080")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메소드
+                        .allowedHeaders("*") // 모든 헤더 허용
+                        .allowCredentials(true) // 인증 정보 포함 허용 (프론트에서 credentials: true 쓸 경우 필요)
+                        .maxAge(3600); // Pre-flight 요청 캐시 시간 (초)
+            }
+        };
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/exception/BusinessException.java
+++ b/src/main/java/com/rofix/fitspot/webservice/exception/BusinessException.java
@@ -1,0 +1,28 @@
+package com.rofix.fitspot.webservice.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode.getMessage(), cause);
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+    super(message, cause);
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/exception/ErrorCode.java
+++ b/src/main/java/com/rofix/fitspot/webservice/exception/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.rofix.fitspot.webservice.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 공통 에러 (1000번대)
+    INVALID_INPUT_VALUE(1000, "잘못된 입력값입니다."),
+    METHOD_NOT_ALLOWED(1001, "지원하지 않는 HTTP 메서드입니다."),
+    ENTITY_NOT_FOUND(1002, "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(1003, "서버 내부 오류가 발생했습니다."),
+    INVALID_TYPE_VALUE(1004, "잘못된 타입의 값입니다."),
+    HANDLE_ACCESS_DENIED(1005, "접근이 거부되었습니다."),
+
+    // 사용자 관련 에러 (2000번대)
+    USER_NOT_FOUND(2000, "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(2001, "이미 존재하는 사용자입니다."),
+    USER_EMAIL_DUPLICATE(2002, "이미 사용 중인 이메일입니다."),
+    USER_INVALID_PASSWORD(2003, "잘못된 비밀번호입니다."),
+    USER_ACCOUNT_LOCKED(2004, "계정이 잠겨있습니다."),
+
+    // 인증/인가 관련 에러 (3000번대)
+    UNAUTHORIZED(3000, "인증이 필요합니다."),
+    FORBIDDEN(3001, "권한이 없습니다."),
+    TOKEN_EXPIRED(3002, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(3003, "유효하지 않은 토큰입니다."),
+
+    // 비즈니스 로직 에러 (4000번대)
+    BUSINESS_RULE_VIOLATION(4000, "비즈니스 규칙을 위반했습니다."),
+    INSUFFICIENT_BALANCE(4001, "잔액이 부족합니다."),
+    ORDER_NOT_FOUND(4002, "주문을 찾을 수 없습니다."),
+
+    // 외부 서비스 에러 (5000번대)
+    EXTERNAL_SERVICE_ERROR(5000, "외부 서비스 오류가 발생했습니다."),
+    EXTERNAL_SERVICE_TIMEOUT(5001, "외부 서비스 응답 시간이 초과되었습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/exception/ErrorResponse.java
+++ b/src/main/java/com/rofix/fitspot/webservice/exception/ErrorResponse.java
@@ -1,0 +1,40 @@
+package com.rofix.fitspot.webservice.exception;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp;
+    private final int status;
+    private final String error;
+    private final int code;
+    private final String message;
+    private final String path;
+
+    public static ErrorResponse of(ErrorCode errorCode, String path) {
+        return ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(errorCode.getCode() / 1000 * 100) // 에러 코드를 HTTP 상태 코드로 변환
+                .error(errorCode.name())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .path(path)
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message, String path) {
+        return ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(errorCode.getCode() / 1000 * 100)
+                .error(errorCode.name())
+                .code(errorCode.getCode())
+                .message(message)
+                .path(path)
+                .build();
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rofix/fitspot/webservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.rofix.fitspot.webservice.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e, HttpServletRequest request) {
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.valueOf(errorResponse.getStatus())).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String message = e.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, message, request.getRequestURI());
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE, request.getRequestURI());
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/exception/UserException.java
+++ b/src/main/java/com/rofix/fitspot/webservice/exception/UserException.java
@@ -1,0 +1,31 @@
+package com.rofix.fitspot.webservice.exception;
+
+public class UserException extends BusinessException {
+  public UserException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public UserException(ErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+
+  public static UserException userNotFound(Long userId) {
+    return new UserException(ErrorCode.USER_NOT_FOUND, "사용자 ID " + userId + "를 찾을 수 없습니다.");
+  }
+
+  public static UserException userNotFound(String email) {
+    return new UserException(ErrorCode.USER_NOT_FOUND, "이메일 " + email + "로 등록된 사용자를 찾을 수 없습니다.");
+  }
+
+  public static UserException userAlreadyExists(String email) {
+    return new UserException(ErrorCode.USER_EMAIL_DUPLICATE, "이메일 " + email + "는 이미 사용 중입니다.");
+  }
+
+  public static UserException invalidPassword() {
+    return new UserException(ErrorCode.USER_INVALID_PASSWORD);
+  }
+
+  public static UserException accountLocked() {
+    return new UserException(ErrorCode.USER_ACCOUNT_LOCKED);
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: jdbc:mysql://next-db.c74828wmikhx.ap-northeast-2.rds.amazonaws.com:3306/rofix?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: admin
+    password: :3M]x0D?29CA1t3mu<c~3|!PhCTI
+  jpa:
+    defer-data-source-initialization: true
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        default_schema: next

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=webservice

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,11 +9,12 @@ server:
 
 spring:
   datasource:
-    url: jdbc:mysql://next-db.c74828wmikhx.ap-northeast-2.rds.amazonaws.com:3306/next?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:mysql://next-db.c74828wmikhx.ap-northeast-2.rds.amazonaws.com:3306/rofix?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: admin
     password: :3M]x0D?29CA1t3mu<c~3|!PhCTI
   jpa:
+    defer-data-source-initialization: true
     hibernate:
       ddl-auto: update
     show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,6 @@
-springdoc:
-  swagger-ui:
-    path: /swagger-ui.html
-  api-docs:
-    path: /api-docs
-
-server:
-  port: 8080
-
 spring:
-  datasource:
-    url: jdbc:mysql://next-db.c74828wmikhx.ap-northeast-2.rds.amazonaws.com:3306/rofix?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: admin
-    password: :3M]x0D?29CA1t3mu<c~3|!PhCTI
+  profiles:
+    active: local # 여기서 값 설정 local(로컬 테스트) , prod(배포용)
   jpa:
     defer-data-source-initialization: true
     hibernate:
@@ -21,5 +9,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
-        default_schema: next
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /api-docs
+
+server:
+  port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /api-docs
+
+server:
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:mysql://next-db.c74828wmikhx.ap-northeast-2.rds.amazonaws.com:3306/next?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: admin
+    password: :3M]x0D?29CA1t3mu<c~3|!PhCTI
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        default_schema: next


### PR DESCRIPTION
## 개요
- Swagger UI 의존성 및 설정 추가
- DB 연결 설정 추가
- localhost:8080 설정 추가
- 예외 처리 클래스 추가
- `application.yml` 수정
- application-local.yml 추가
- applicatyion-prod.yml 추가
- Entity 추가

## 상세 내용
- `build.gradle`
  - Swagger-UI 관련 의존성 추가 (`springdoc-openapi-ui`)
- `application.yml`
  - DB 접속 정보 및 서버 포트(8080) 설정
  - Swagger UI 경로 `/swagger-ui.html`, API Docs 경로 `/api-docs` 지정
  - 테이블 의존성으로 인한 오류 발생 때문에 데이터 초기화 시점 변경
  - prod/local 환경 구분 <- prod 디비 자원 낭비 방지 위해 설정
    - application.yml activ 에서 local / prod 선택해서 실행시킬 수 있음 
    
<img width="690" height="100" alt="image" src="https://github.com/user-attachments/assets/10e6e7b7-2400-42c5-a656-e6ee3a8d3661" />


    - 로컬 디비는 h2 사용하고 있으며 확인하기 위해서는 아래 주소로 접속하면 확인 가능
      - http://localhost:8080/h2-console
      - JDBC url : jdbc:h2:mem:testdb
      
<img width="518" height="445" alt="image" src="https://github.com/user-attachments/assets/3d334258-a4c3-4380-9557-09b6974ae9d9" />


- `OpenApiConfig`
  - OpenAPI Bean 등록
  - API 문서 기본 정보(title, description, version) 설정
- `WebConfig`, `OpenApiConfig`
  - 로컬 8080에서 API 호출가능 하도록 설정
- `BusinessException` 등
  - 예외 처리 클래스 추가
- `Entity` 생성
  - 기존에 작성된 테이블 정의서 기반으로 entity 생성 
  - => entity 생성만 하고 service, repository, controller 미 생성으로 인해 swagger-ui 페이지는 현재 500 에러 뜸 **postman 등으로 API 확인 가능**

## 변경 유형
✅ 빌드 (build)
✅ 신규 기능 추가 (feat)

## TODO
- 테이블간 의존성으로 인해 Drop이 연계된 테이블을 먼저 삭제해야지 동작함. cascade 고려 필요
- CORS 설정 
