### PR TITLE
[feat] Clothes API 및 S3 이미지 업로드 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # next-rofix-backend
-Team Rofix backend repository
+
+## PROD / LOCAL 환경 선택
+### `applicaiotn.yml` active 에서 local / prod 선택해서 빌드하고 실행시킬 수 있습니다.
+<img width="690" height="100" alt="image" src="https://github.com/user-attachments/assets/10e6e7b7-2400-42c5-a656-e6ee3a8d3661" />
+
+## Local DB (h2) 사용 방법
+### sprig boot local 환경으로 실행 시킨 후 h2 주소로 접속하면 확인할 수 있습니다.
+- `http://localhost:8080/h2-console`
+- JDBC url : `jdbc:h2:mem:testdb`
+
+<img width="518" height="445" alt="image" src="https://github.com/user-attachments/assets/3d334258-a4c3-4380-9557-09b6974ae9d9" />

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation platform('software.amazon.awssdk:bom:2.25.4') // BOM
+	implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
@@ -2,13 +2,20 @@ package com.rofix.fitspot.webservice.api.user.controller;
 
 import com.rofix.fitspot.webservice.api.user.entity.Clothing;
 import com.rofix.fitspot.webservice.api.user.service.ClothingService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/clothes")
+@Slf4j
 public class ClothingController {
 
     @Autowired
@@ -24,8 +31,20 @@ public class ClothingController {
         return clothingService.getClothesByUserID(userId);
     }
 
-    // 옷 생성 - s3 로직
+    // 옷 생성
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Clothing> createClothing(
+            @RequestPart("clothing") Clothing clothing,
+            @RequestPart(value = "file", required = false) MultipartFile file
+    ) throws IOException {
+        Clothing saved = clothingService.createClothing(clothing, file);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
 
-
-    // 옷 삭제 - s3 로직 적용
+    // 옷 삭제
+    @DeleteMapping("/{clothingId}")
+    public ResponseEntity<Void> deleteClothing(@PathVariable Long clothingId) {
+        clothingService.deleteClothing(clothingId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
@@ -1,0 +1,31 @@
+package com.rofix.fitspot.webservice.api.user.controller;
+
+import com.rofix.fitspot.webservice.api.user.entity.Clothing;
+import com.rofix.fitspot.webservice.api.user.service.ClothingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/clothes")
+public class ClothingController {
+
+    @Autowired
+    private ClothingService clothingService;
+
+    // 전체 옷 조회
+    @GetMapping
+    public List<Clothing> getAllClothes() {return clothingService.getAllClothes();}
+
+    // userId 별 옷 조회
+    @GetMapping("/user/{userId}")
+    public List<Clothing> getAllClothes (@PathVariable Long userId) {
+        return clothingService.getClothesByUserID(userId);
+    }
+
+    // 옷 생성 - s3 로직
+
+
+    // 옷 삭제 - s3 로직 적용
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -45,10 +47,11 @@ public class Clothing {
     @Column
     private String description;
 
+    @CreationTimestamp
     @Column(nullable = false, name = "created_at")
     private LocalDateTime createdAt;
 
     // Cody_Clothes와의 관계 1:N
-    @OneToMany(mappedBy = "cloth")
+    @OneToMany(mappedBy = "clothing")
     private List<CodyClothes> codyClothes;
 }

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,8 +34,12 @@ public class Clothing {
     @Column(nullable = false)
     private String color;
 
-    @Column(nullable = false, name = "image_url")
+    @Column(name = "image_url")
     private String imageUrl;
+
+    // S3 객체 key (식별용)
+    @Column(name = "image_key")
+    private String imageKey;
 
     @Column
     private String brand;
@@ -48,7 +51,7 @@ public class Clothing {
     private String description;
 
     @CreationTimestamp
-    @Column(nullable = false, name = "created_at")
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     // Cody_Clothes와의 관계 1:N

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/CodyClothes.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/CodyClothes.java
@@ -23,5 +23,5 @@ public class CodyClothes {
 
     @ManyToOne
     @JoinColumn(name = "clothing_id")
-    private Clothing cloth;
+    private Clothing clothing;
 }

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/repository/ClothingRepository.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/repository/ClothingRepository.java
@@ -1,0 +1,12 @@
+package com.rofix.fitspot.webservice.api.user.repository;
+
+import com.rofix.fitspot.webservice.api.user.entity.Clothing;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ClothingRepository extends JpaRepository<Clothing, Long> {
+    List<Clothing> findByUserUserId(Long userid);
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/service/ClothingService.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/service/ClothingService.java
@@ -1,0 +1,34 @@
+package com.rofix.fitspot.webservice.api.user.service;
+
+import com.rofix.fitspot.webservice.api.user.entity.Clothing;
+import com.rofix.fitspot.webservice.api.user.repository.ClothingRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class ClothingService {
+
+    @Autowired
+    private ClothingRepository clothingRepository;
+
+    // 옷 전체 조회
+    public List<Clothing> getAllClothes() {return clothingRepository.findAll();}
+
+    // userId 별 옷 조회
+    public List<Clothing> getClothesByUserID(Long userId) {
+        return clothingRepository.findByUserUserId(userId);
+    }
+
+    // 옷 생성 - s3 고려 필요
+    public Clothing createClothing(Clothing clothing) {
+        // @TODO S3 업로드 로직 필요
+        return clothingRepository.save(clothing);
+    }
+
+    // 옷 삭제 @TODO S3에서 해당 이미지 파일 삭제로직도 같이 필요
+    public void deleteClothing(Long id) {clothingRepository.deleteById(id);}
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/service/ClothingService.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/service/ClothingService.java
@@ -2,10 +2,13 @@ package com.rofix.fitspot.webservice.api.user.service;
 
 import com.rofix.fitspot.webservice.api.user.entity.Clothing;
 import com.rofix.fitspot.webservice.api.user.repository.ClothingRepository;
+import com.rofix.fitspot.webservice.aws.S3Service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -15,6 +18,9 @@ public class ClothingService {
     @Autowired
     private ClothingRepository clothingRepository;
 
+    @Autowired
+    private S3Service s3Service;
+
     // 옷 전체 조회
     public List<Clothing> getAllClothes() {return clothingRepository.findAll();}
 
@@ -23,12 +29,39 @@ public class ClothingService {
         return clothingRepository.findByUserUserId(userId);
     }
 
-    // 옷 생성 - s3 고려 필요
-    public Clothing createClothing(Clothing clothing) {
-        // @TODO S3 업로드 로직 필요
-        return clothingRepository.save(clothing);
+    // 옷 생성
+    public Clothing createClothing(Clothing clothing, MultipartFile file) throws IOException {
+        String key = null;
+        try {
+            if (file != null && !file.isEmpty()) {
+                key = s3Service.uploadFile(file, clothing.getUser().getUserId());
+                clothing.setImageKey(key);
+                clothing.setImageUrl(s3Service.getUrlForKey(key));
+            }
+            return clothingRepository.save(clothing);
+        } catch (Exception e) {
+            if (key != null) {
+                try {
+                    s3Service.deleteFile(key);
+                } catch (Exception ex) {
+                    log.warn("S3 rollback failed for key {}", key, ex);
+                }
+            }
+            throw e;
+        }
     }
 
-    // 옷 삭제 @TODO S3에서 해당 이미지 파일 삭제로직도 같이 필요
-    public void deleteClothing(Long id) {clothingRepository.deleteById(id);}
+    // 옷 삭제
+    public void deleteClothing(Long clothingId) {
+        clothingRepository.findById(clothingId).ifPresent( clothing -> {
+            if (clothing.getImageKey() != null) {
+                try {
+                    s3Service.deleteFile(clothing.getImageKey());
+                } catch (Exception e) {
+                    log.warn("S3 delete failed for key {}", clothing.getImageKey(), e);
+                }
+            }
+            clothingRepository.deleteById(clothingId);
+        });
+    }
 }

--- a/src/main/java/com/rofix/fitspot/webservice/aws/S3Service.java
+++ b/src/main/java/com/rofix/fitspot/webservice/aws/S3Service.java
@@ -1,0 +1,54 @@
+package com.rofix.fitspot.webservice.aws;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service{
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile file, Long userId) throws IOException {
+        String key = "clothing/" + userId + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        PutObjectRequest por = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(por, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        log.info("Uploaded file to S3 with key: {}", key);
+        return key;
+    }
+
+    public String getUrlForKey(String key) {
+        return s3Client.utilities()
+                .getUrl(GetUrlRequest.builder().bucket(bucket).key(key).build())
+                .toString();
+    }
+
+    public void deleteFile(String key) {
+        DeleteObjectRequest dor = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+        s3Client.deleteObject(dor);
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/config/S3Config.java
+++ b/src/main/java/com/rofix/fitspot/webservice/config/S3Config.java
@@ -1,0 +1,23 @@
+package com.rofix.fitspot.webservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,14 @@ spring:
       hibernate:
         format_sql: true
 
+aws:
+  s3:
+    bucket: jaden-firehose-bucket     # 여기에 버킷 이름
+  region:
+    static: ap-northeast-2     # 리전
+  stack:
+    auto: false
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## 개요
- `clothes` API 기능 구축
- S3 이미지 업로드 기능 구현 및 연동
- `clothing`, `codyclothes` 엔티티 변수명 수정
- `README` 파일 수정

## 상세 내용
### 1. S3 관련
- `AWS S3` 의존성 추가
- S3 파일 업로드를 위한 `config` 및 `service` 추가
- S3 이미지 등록 로직 구현
- `clothes` API에 S3 관련 로직 적용 (파일 업로드 및 관리)

### 2. clothes API
- clothes API 서비스 추가
- S3 이미지 업로드 기능과 연동하여 옷 전체 조회, userId 별 옷 조회, 옷 등록, 삭제 기능 구현

### 3. 리팩토링
- `clothing`, `codyclothes` 엔티티에서 변수 변경:  `cloth` -> `clothing`

### 4. 문서
- README 파일 수정

## 변경 유형
✅ 기능 추가 (feat)
✅ 리팩토링 (refactor)
✅ 빌드 (build)
✅ 문서 수정 (docs)

## TODO
- 옷 등록 관련한 DTO 고려
- swagger-ui  삭제
- 이미지 적재할 S3 버킷 생성