### PR TITLE
[refactor, clothes] DTO 적용 및 S3 presigned URL 로직 추가

### DIFF
--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
@@ -1,5 +1,7 @@
 package com.rofix.fitspot.webservice.api.user.controller;
 
+import com.rofix.fitspot.webservice.api.user.dto.ClothingDTO;
+import com.rofix.fitspot.webservice.api.user.dto.ClothingRequestDTO;
 import com.rofix.fitspot.webservice.api.user.entity.Clothing;
 import com.rofix.fitspot.webservice.api.user.service.ClothingService;
 import lombok.extern.slf4j.Slf4j;
@@ -23,21 +25,21 @@ public class ClothingController {
 
     // 전체 옷 조회
     @GetMapping
-    public List<Clothing> getAllClothes() {return clothingService.getAllClothes();}
+    public List<ClothingDTO> getAllClothes() {return clothingService.getAllClothes();}
 
     // userId 별 옷 조회
     @GetMapping("/user/{userId}")
-    public List<Clothing> getAllClothes (@PathVariable Long userId) {
+    public List<ClothingDTO> getAllClothes (@PathVariable Long userId) {
         return clothingService.getClothesByUserID(userId);
     }
 
     // 옷 생성
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Clothing> createClothing(
-            @RequestPart("clothing") Clothing clothing,
+    public ResponseEntity<ClothingDTO> createClothing(
+            @RequestPart("clothing") ClothingRequestDTO dto,
             @RequestPart(value = "file", required = false) MultipartFile file
     ) throws IOException {
-        Clothing saved = clothingService.createClothing(clothing, file);
+        ClothingDTO saved = clothingService.createClothing(dto, file);
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/dto/ClothingDTO.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/dto/ClothingDTO.java
@@ -1,0 +1,24 @@
+package com.rofix.fitspot.webservice.api.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClothingDTO {
+    private Long clothingId;
+    private Long userId;   // User 객체 대신 userId만
+    private String title;
+    private String category;
+    private String color;
+    private String imageUrl;
+    private String imageKey;
+    private String brand;
+    private String weather;
+    private String description;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/dto/ClothingMapper.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/dto/ClothingMapper.java
@@ -1,0 +1,38 @@
+package com.rofix.fitspot.webservice.api.user.dto;
+
+import com.rofix.fitspot.webservice.api.user.entity.Clothing;
+import com.rofix.fitspot.webservice.api.user.entity.User;
+
+public class ClothingMapper {
+    public static ClothingDTO toDTO(Clothing clothing) {
+        return new ClothingDTO(
+            clothing.getClothingId(),
+            clothing.getUser() != null ? clothing.getUser().getUserId() : null,
+            clothing.getTitle(),
+            clothing.getCategory(),
+            clothing.getColor(),
+            clothing.getImageUrl(),
+            clothing.getImageKey(),
+            clothing.getBrand(),
+            clothing.getWeather(),
+            clothing.getDescription(),
+            clothing.getCreatedAt()
+        );
+    }
+
+    public static Clothing toEntity(ClothingRequestDTO dto) {
+        Clothing clothing = new Clothing();
+        if (dto.getUserId() != null) {
+            User user = new User();
+            user.setUserId(dto.getUserId());
+            clothing.setUser(user);
+        }
+        clothing.setTitle(dto.getTitle());
+        clothing.setCategory(dto.getCategory());
+        clothing.setColor(dto.getColor());
+        clothing.setBrand(dto.getBrand());
+        clothing.setWeather(dto.getWeather());
+        clothing.setDescription(dto.getDescription());
+        return clothing;
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/dto/ClothingRequestDTO.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/dto/ClothingRequestDTO.java
@@ -1,0 +1,14 @@
+package com.rofix.fitspot.webservice.api.user.dto;
+
+import lombok.Data;
+
+@Data
+public class ClothingRequestDTO {
+    private Long userId;
+    private String title;
+    private String category;
+    private String color;
+    private String brand;
+    private String weather;
+    private String description;
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/Clothing.java
@@ -34,7 +34,7 @@ public class Clothing {
     @Column(nullable = false)
     private String color;
 
-    @Column(name = "image_url")
+    @Column(name = "image_url", length = 1024)
     private String imageUrl;
 
     // S3 객체 key (식별용)
@@ -45,7 +45,7 @@ public class Clothing {
     private String brand;
 
     @Column
-    private String season;
+    private String weather;
 
     @Column
     private String description;

--- a/src/main/java/com/rofix/fitspot/webservice/config/S3Config.java
+++ b/src/main/java/com/rofix/fitspot/webservice/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -16,6 +17,14 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
 aws:
   s3:
-    bucket: jaden-firehose-bucket     # 여기에 버킷 이름
+    bucket: fitspot-bucket     # 여기에 버킷 이름
   region:
     static: ap-northeast-2     # 리전
   stack:


### PR DESCRIPTION
## 개요

- `clothes`  DTO 생성
- DTO에 따른 service, controller 추가
- S3 이미지 업로드 기능 수정 및 연동
- bucket 이름 변경

## 상세 내용

### 1. S3 관련
- 기존 저장하는 S3 url이 아닌 **Presigned URL** 로 수정을 위해 `S3Config` 및 `S3Service` 수정
- ** Presigned URL** 저장을 위해 `Clothing` 엔티티의 `imageUrl` 컬럼 길이를 `1024`로 확장

### 2. `clothes` API
- Clothes DTO 적용을 위해 `clothes` API 서비스 수정 

### 3. 리팩토링
- `Clothing` 엔티티에서 변수명 변경: `season` -> `weather`으로 변경하였습니다.
- `applicaiton.yml` 에 bucket 이름 변경


## 변경 유형

- ✅ 기능 추가 (feat)
- ✅ 리팩토링 (refactor)


## TODO
- `swagger-ui` 삭제