### PR TITLE
[fix] clothes등록 위한 session 관련 로직 추가

### DIFF
--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/ClothingController.java
@@ -2,10 +2,11 @@ package com.rofix.fitspot.webservice.api.user.controller;
 
 import com.rofix.fitspot.webservice.api.user.dto.ClothingDTO;
 import com.rofix.fitspot.webservice.api.user.dto.ClothingRequestDTO;
-import com.rofix.fitspot.webservice.api.user.entity.Clothing;
+import com.rofix.fitspot.webservice.api.user.entity.User;
 import com.rofix.fitspot.webservice.api.user.service.ClothingService;
+import jakarta.servlet.http.HttpSession;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -18,34 +19,47 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/clothes")
 @Slf4j
+@AllArgsConstructor
 public class ClothingController {
 
-    @Autowired
-    private ClothingService clothingService;
+    private final ClothingService clothingService;
 
     // 전체 옷 조회
     @GetMapping
     public List<ClothingDTO> getAllClothes() {return clothingService.getAllClothes();}
 
     // userId 별 옷 조회
-    @GetMapping("/user/{userId}")
-    public List<ClothingDTO> getAllClothes (@PathVariable Long userId) {
-        return clothingService.getClothesByUserID(userId);
+    @GetMapping("/user")
+    public ResponseEntity<List<ClothingDTO>> getMyClothes(HttpSession session) {
+        User currentUser = (User) session.getAttribute("user");
+        if (currentUser == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // 서비스 메서드를 세션 기반으로 호출하도록 변경
+        List<ClothingDTO> clothesList = clothingService.getClothesByUserID(currentUser.getUserId());
+        return ResponseEntity.ok(clothesList);
     }
 
     // 옷 생성
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ClothingDTO> createClothing(
             @RequestPart("clothing") ClothingRequestDTO dto,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @RequestPart(value = "file", required = false) MultipartFile file,
+            HttpSession session
     ) throws IOException {
-        ClothingDTO saved = clothingService.createClothing(dto, file);
+        User currentUser = (User) session.getAttribute("user");
+        if (currentUser == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        ClothingDTO saved = clothingService.createClothing(dto, file, currentUser.getUserId());
         return ResponseEntity.status(HttpStatus.CREATED).body(saved);
     }
 
     // 옷 삭제
     @DeleteMapping("/{clothingId}")
     public ResponseEntity<Void> deleteClothing(@PathVariable Long clothingId) {
+        log.info("DELETED ID 해결: "+String.valueOf(clothingId));
         clothingService.deleteClothing(clothingId);
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
## 변경내용
1. 인증 로직 추가
    - @GetMapping("/user") 엔드포인트에 HttpSession을 통해 현재 로그인된 유저(currentUser) 정보를 가져오도록 변경했습니다.
    - 유저 정보가 없는 경우, 401 Unauthorized 응답을 반환하도록 처리했습니다.
3. 옷 조회 로직 수정
    - Path Variable로 userId를 받는 기존 getAllClothes 메서드를 삭제했습니다.
    - 새로운 getClothesByUser 메서드는 로그인된 유저의 userId를 사용하여 옷 리스트를 조회합니다.
5. 옷 생성 및 삭제 로직 수정
    - createClothing 및 deleteClothing 메서드에 현재 로그인된 유저의 정보를 활용하여 로직을 수행하도록 수정했습니다.

## TODO
- 옷 생성 로직 수정 필요 ->  프론트 단에서 JSESSION 값이 있어야 post 가능