### PR TITLE
[refactor] User 객체의 LAZY 필드 제거, Serializable 구현 등 리팩토링 및 UserMapper 추가

### DIFF
--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/LoginController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/LoginController.java
@@ -2,72 +2,63 @@ package com.rofix.fitspot.webservice.api.user.controller;
 
 import com.rofix.fitspot.webservice.api.user.entity.User;
 import com.rofix.fitspot.webservice.api.user.dto.UserDTO;
+import com.rofix.fitspot.webservice.api.user.mapper.UserMapper;
 import com.rofix.fitspot.webservice.api.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
 @Slf4j
+@AllArgsConstructor
 public class LoginController {
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
     @PostMapping("/login")
-    public ResponseEntity<?>  login(@RequestBody Map<String, String> payload, HttpServletRequest request) {
+    public ResponseEntity<Map<String, Object>>  login(@RequestBody Map<String, String> payload, HttpServletRequest request) {
         String email = payload.get("email");
         if (email == null || email.isEmpty()) {
-            return ResponseEntity.badRequest().body("이메일이 누락되었습니다.");
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("message", "이메일이 누락되었습니다.");
+            return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
         }
 
         // 새로운 세션 생성 (세션이 없으면 새로 만들고, 있으면 기존 세션을 사용)
         HttpSession session = request.getSession(true);
-
-        // UserService를 통해 DB에서 User 정보를 가져오거나 새로 생성합니다.
-        // 이 과정에서 세션에 유저 정보를 명확하게 등록합니다.
         User user = userService.handleUserLogin(email, session);
 
-        // User 객체를 UserDTO로 변환하여 클라이언트에 필요한 정보만 전달합니다.
-        UserDTO dto = new UserDTO(
-                user.getUserId(),
-                user.getEmail(),
-                user.getNickname(),
-                user.getPersonalColor(),
-                user.getCreatedAt()
-        );
+        // Mapper 사용하여 User 객체를 DTO로 변환
+        UserDTO userDTO = UserMapper.toDTO(user);
 
         return ResponseEntity.ok(Map.of(
                 "message", "로그인 성공",
-                "user", dto
+                "user", userDTO
         ));
     }
 
     // 로그인 상태를 확인하는 API (프런트엔드에서 세션 유효성 체크용)
     @GetMapping("/check")
-    public ResponseEntity<?> checkLogin(HttpSession session) {
+    public ResponseEntity<Map<String, Object>> checkLogin(HttpSession session) {
         try {
             // 세션에서 'user' 객체를 가져옴
             Object userObj = session.getAttribute("user");
 
             // user 객체가 존재하고, 타입이 User인지 확인
             if (userObj instanceof User user) {
-                // 세션에서 가져온 User 객체를 UserDTO로 변환하여 반환합니다.
-                UserDTO dto = new UserDTO(
-                        user.getUserId(),
-                        user.getEmail(),
-                        user.getNickname(),
-                        user.getPersonalColor(),
-                        user.getCreatedAt()
-                );
-                return ResponseEntity.ok(Map.of("user", dto));
+                // Mapper 사용해서 User 객체를 DTO로 변환
+                UserDTO userDTO = UserMapper.toDTO(user);
+
+                return ResponseEntity.ok(Map.of("user", userDTO));
             } else {
                 // user 객체가 없거나 유효하지 않으면 401 Unauthorized 응답 반환
                 return ResponseEntity.status(401).body(Collections.singletonMap("user", null));
@@ -81,7 +72,7 @@ public class LoginController {
 
     // 로그아웃을 처리하는 API
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(HttpSession session) {
+    public ResponseEntity<String> logout(HttpSession session) {
         session.invalidate();
         return ResponseEntity.ok("로그아웃 성공!");
     }

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/LoginController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/LoginController.java
@@ -49,24 +49,16 @@ public class LoginController {
     // 로그인 상태를 확인하는 API (프런트엔드에서 세션 유효성 체크용)
     @GetMapping("/check")
     public ResponseEntity<Map<String, Object>> checkLogin(HttpSession session) {
-        try {
-            // 세션에서 'user' 객체를 가져옴
-            Object userObj = session.getAttribute("user");
+        Object userObj = session.getAttribute("user");
 
-            // user 객체가 존재하고, 타입이 User인지 확인
-            if (userObj instanceof User user) {
-                // Mapper 사용해서 User 객체를 DTO로 변환
-                UserDTO userDTO = UserMapper.toDTO(user);
-
-                return ResponseEntity.ok(Map.of("user", userDTO));
-            } else {
-                // user 객체가 없거나 유효하지 않으면 401 Unauthorized 응답 반환
-                return ResponseEntity.status(401).body(Collections.singletonMap("user", null));
-            }
-        } catch (Exception e) {
-            // 예상치 못한 예외가 발생하면 로그를 남기고, 401 Unauthorized 응답 반환
-            log.error("세션 확인 중 예외 발생", e);
-            return ResponseEntity.status(401).body(Collections.singletonMap("user", null));
+        // user 객체가 존재하면
+        if (userObj instanceof User user) {
+            UserDTO userDTO = UserMapper.toDTO(user);
+            return ResponseEntity.ok(Map.of("user", userDTO));
+        } else {
+            // user 객체가 없으면, 401 대신 200 OK 응답을 보내고 user: null을 포함
+            // 콘솔에 401 에러 뜨는 것 방지
+            return ResponseEntity.ok(Collections.singletonMap("user", null));
         }
     }
 

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/controller/LoginController.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/controller/LoginController.java
@@ -1,7 +1,7 @@
 package com.rofix.fitspot.webservice.api.user.controller;
 
 import com.rofix.fitspot.webservice.api.user.entity.User;
-import com.rofix.fitspot.webservice.api.user.entity.UserDTO;
+import com.rofix.fitspot.webservice.api.user.dto.UserDTO;
 import com.rofix.fitspot.webservice.api.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -56,7 +56,6 @@ public class LoginController {
         try {
             // 세션에서 'user' 객체를 가져옴
             Object userObj = session.getAttribute("user");
-            log.info("세션에서 user 객체 확인 : {}", userObj);
 
             // user 객체가 존재하고, 타입이 User인지 확인
             if (userObj instanceof User user) {

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/dto/UserDTO.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/dto/UserDTO.java
@@ -1,4 +1,4 @@
-package com.rofix.fitspot.webservice.api.user.entity;
+package com.rofix.fitspot.webservice.api.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -36,18 +37,22 @@ public class User {
 
     // Clothes와 관계 1:N
     @OneToMany(mappedBy = "user")
+    @ToString.Exclude
     private List<Clothing> clothes;
 
     // Cody와 관계
     @OneToMany(mappedBy = "user")
+    @ToString.Exclude
     private List<Cody> cody;
 
     // Comments와 관계
     @OneToMany(mappedBy = "user")
+    @ToString.Exclude
     private List<Comment> comments;
 
     // Likes와 관계
     @OneToMany(mappedBy = "user")
+    @ToString.Exclude
     private List<Like> likes;
 
 }

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,7 +16,10 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class User implements Serializable {
+
+    // 직렬화 처리
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/mapper/UserMapper.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/mapper/UserMapper.java
@@ -1,0 +1,38 @@
+package com.rofix.fitspot.webservice.api.user.mapper;
+
+import com.rofix.fitspot.webservice.api.user.dto.UserDTO;
+import com.rofix.fitspot.webservice.api.user.entity.User;
+
+public final class UserMapper {
+
+    // 외부에서 인스턴스 생성을 막기 위해 private 생성자 추가
+    private UserMapper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static UserDTO toDTO(User user) {
+        if (user == null) {
+            return null;
+        }
+        return new UserDTO(
+                user.getUserId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getPersonalColor(),
+                user.getCreatedAt()
+        );
+    }
+
+    public static User toEntity(UserDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        User user = new User();
+        user.setUserId(dto.getUserId());
+        user.setEmail(dto.getEmail());
+        user.setNickname(dto.getNickname());
+        user.setPersonalColor(dto.getPersonalColor());
+        user.setCreatedAt(dto.getCreatedAt());
+        return user;
+    }
+}

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/service/UserService.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/service/UserService.java
@@ -7,7 +7,6 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -29,7 +28,6 @@ public class UserService {
                     User newUser = new User();
                     newUser.setEmail(email);
                     newUser.setNickname("user_" + UUID.randomUUID().toString().substring(0, 8));
-                    newUser.setCreatedAt(LocalDateTime.now());
                     return userRepository.save(newUser); // DB에 저장하고 반환
                 });
 


### PR DESCRIPTION
## 개요
- LazyInitializationException 해결을 위한 `User` 객체의 LAZY 필드 제거
- UserDTO 위치 수정
- User 객체에 Serializable 인터페이스 구현
- UserMapper 추가
-  LoginController 와일드카드 삭제

## 상세 내용
### 1. 리팩토링
- LazyInitializationException 방지를 위해 `User` 객체에서 LAZY 로딩 필드 제거
- UserDTO 클래스의 위치를 변경하여 프로젝트 구조 개선 
- User 객체에 직렬화 처리를 위한 Serializable 인터페이스 구현
- LoginController의 와일드카드를 삭제하고 특정 경로만 허용하도록 수정

### 2. 기능 추가
- UserMapper를 추가하여 사용자 관련 매핑 로직을 구현

## 변경 유형
✅ 리팩토링 (refactor)
✅ 기능 추가 (feat)

## TODO
- 직렬화가 필요한 다른 객체에도 Serializable 구현 여부 검토
- `ClothesMapper` 위치 이동 및 수정