### PR TITLE
[fix] User Entity Cascade 옵션 추가

### DIFF
--- a/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/entity/User.java
@@ -40,22 +40,22 @@ public class User implements Serializable {
     private LocalDateTime createdAt;
 
     // Clothes와 관계 1:N
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @ToString.Exclude
     private List<Clothing> clothes;
 
     // Cody와 관계
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @ToString.Exclude
     private List<Cody> cody;
 
     // Comments와 관계
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @ToString.Exclude
     private List<Comment> comments;
 
     // Likes와 관계
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @ToString.Exclude
     private List<Like> likes;
 

--- a/src/main/java/com/rofix/fitspot/webservice/api/user/service/UserService.java
+++ b/src/main/java/com/rofix/fitspot/webservice/api/user/service/UserService.java
@@ -42,49 +42,6 @@ public class UserService {
         return userRepository.findById(userId);
     }
 
-    // 닉네임 수정
-    public User updateNickname(Long userId, String newNickname) {
-        if (newNickname == null || newNickname.isEmpty()) {
-            throw new IllegalArgumentException("닉네임은 필수 입력 항목입니다.");
-        }
-
-        return userRepository.findById(userId)
-                .map(user -> {
-                    user.setNickname(newNickname);
-                    return userRepository.save(user);
-                })
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-    }
-
-    // 퍼스널컬러만 업데이트
-    public User updatePersonalColor(Long userId, String newPersonalColor) {
-        if (newPersonalColor == null || newPersonalColor.isEmpty()) {
-            throw new IllegalArgumentException("퍼스널컬러는 필수 입력 항목입니다.");
-        }
-
-        return userRepository.findById(userId)
-                .map(user -> {
-                    user.setPersonalColor(newPersonalColor);
-                    return userRepository.save(user);
-                })
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-    }
-
-    // 이메일만 수정
-    public User updateEmail(Long userId, String newEmail) {
-        if (newEmail == null || newEmail.isEmpty()) {
-            throw new IllegalArgumentException("닉네임은 필수 입력 항목입니다.");
-        }
-
-        return userRepository.findById(userId)
-                .map(user -> {
-                    user.setEmail(newEmail);
-                    return userRepository.save(user);
-                })
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-    }
-
     // 회원 정보 수정 (이메일, 닉네임, 퍼스널컬러)
     public User updateUser(Long userId, String email, String nickname, String personalColor) {
         return userRepository.findById(userId)


### PR DESCRIPTION
## 개요
- `User` Entity **cascade** 옵션 추가
- `UserService` 사용하지 않는 메서드 삭제

## 상세 내용
### 1. `User` Entity cascade 옵션 추가
- 옷이 등록되어 있는 경우에 회원탈퇴가 안되는 이슈 발생 
=> `User` entity에 **cascade** 옵션 추가해서 해결

### 2. `UserService` 사용하지 않는 메서드 삭제
- nickname, email, personalcolor 파라미터를 모두 받아서 update하는 기능만 유지

## 변경 유형
✅ 리팩토링 (refactor)
✅ 버그 수정 (fix)

## TODO
- `Cody` entity에도 **cascade** 옵션 추가 고려 필요
